### PR TITLE
17 implement support of the single end data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ uv run nextflow main.nf \
     --library <amplicon/rnaseq> \
     --fq1 "R1.fastq.gz" \
     --fq2 "R2.fastq.gz" \
+    --<paired\single>
     --outdir "./results"
 ```
 
@@ -61,12 +62,12 @@ uv run nextflow main.nf \
 ## Pipeline summary
 
 `pyigmap` allows the processing of raw BCR/TCR sequencing data from **bulk** and **targeted** sequencing protocols.
-For more details on the supported protocols, please refer to the [usage](#Usage) documentation.
+For more details on the supported protocols, please refer to the [usage](#usage) documentation.
 
 ### 1. FASTQ pre-processing
 
 * RNASeq-bulk:
-  * Merging overlapping reads, joining non-overlapping reads with a selected insert size, and raw read quality control (`Fastp`).
+  * Merging overlapping reads, joining non-overlapping reads with a selected insert size, and raw read quality control for paired-end data (`Fastp`).
 
 * AIRR-Seq (target):
   * Extracting the UMI from the reads (`PyUMI`).
@@ -96,25 +97,30 @@ For more details on the supported protocols, please refer to the [usage](#Usage)
 
 ## Usage
 
+**RNASeq workflow** supports both single‑end and paired‑end input data. Specify the sequencing mode explicitly using either the `--single` or `--paired` flag when launching the pipeline. **Amplicon workflow** requires paired‑end input and must be executed with the `--paired` flag.
+
 A typical command to run the pipeline from **RNASeq-bulk** sequencing data is:
 
 ```bash
-uv run nextflow -profile <docker/podman> \
+uv run nextflow main.nf \
+    -profile <docker/podman> \
     --library rnaseq \
     --fq1 "R1.fastq.gz" \
     --fq2 "R2.fastq.gz" \
+    --<paired\single>
     --outdir "./results"
 ```
-
 For common **AIRR-Seq targeted** sequencing protocols we provide pre-set parameters, including a parameter for specifying a UMI barcode pattern.  
 
 Here is an example command to process the data from the **AIRR-Seq targeted** protocol, where there is a 19-base pair UMI located between two adapters in the reverse FASTQ file:
 
 ```bash
-uv run nextflow -profile <docker/podman> \
+uv run nextflow main.nf \
+    -profile <docker/podman> \
     --library amplicon \
     --fq1 "R1.fastq.gz" \
     --fq2 "R2.fastq.gz" \
+    --paired \
     --fq2_pattern "^TGGTATCAACGCAGAGTAC(UMI:N{19})TCTTGGGGG" \
     --outdir "./results"
 ```
@@ -122,19 +128,23 @@ uv run nextflow -profile <docker/podman> \
 You can also use public data from these databases by using a sample ID: [GEO](https://www.ncbi.nlm.nih.gov/geo/), [SRA](https://www.ncbi.nlm.nih.gov/sra), [EMBL-EBI](https://www.ebi.ac.uk/), [DDBJ](https://www.ddbj.nig.ac.jp/index-e.html), [NIH Biosample](https://www.ncbi.nlm.nih.gov/biosample) and [ENCODE](https://www.encodeproject.org/):
 
 ```bash
-uv run nextflow -profile <docker/podman> \
+uv run nextflow main.nf \
+    -profile <docker/podman> \
     --library rnaseq \
     --sample_id SRR3743469 \
+    --paired \
     --outdir "./results"
 ```
 
 Alternatively, you can provide an HTTP/HTTPS/FTP link to your FASTQ files.
 
 ```bash
-uv run nextflow -profile <docker/podman> \
+uv run nextflow main.nf \
+    -profile <docker/podman> \
     --library amplicon \
     --fq1 https://zenodo.org/records/11103555/files/fmba_TRAB_R1.fastq.gz \
     --fq2 https://zenodo.org/records/11103555/files/fmba_TRAB_R2.fastq.gz \
+    --paired \
     --outdir "./results"
 ```
 

--- a/bin/cdr3nt_error_corrector/run.py
+++ b/bin/cdr3nt_error_corrector/run.py
@@ -235,7 +235,7 @@ def parse_total_reads(json_files: list[str]) -> dict:
             logger.warning(f'Total reads count could not be found in {json_file}')
         else:
             total_reads_count += int(json_content.get('summary', 0).get('before_filtering', 0).get('total_reads', 0))
-            if 'fastp_version' in json_content['summary']:
+            if 'fastp_version' in json_content['summary'] and 'paired end' in json_content['summary']['sequencing']:
                 total_reads_count //= 2
     return {"total_reads": total_reads_count}
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -55,7 +55,7 @@ process {
             mode: "copy"
         ]
     }
-    withName: "FastpMerge|FastpMockMerge" {
+    withName: "FastpMerge|FastpMockMerge|FastpSingle" {
         container = "fastp-image"
         publishDir = [
             path: "${params.outdir}/fastp",

--- a/modules/local/downloader.nf
+++ b/modules/local/downloader.nf
@@ -1,6 +1,6 @@
 process GetLinks {
     // labels are defined in conf/base.config
-    // label "process_single"
+    // label "Get_links_from_SRA_ID"
 
     input:
         val sample_id
@@ -11,23 +11,21 @@ process GetLinks {
 
     script:
         """
-        link_1=\$(ffq --ftp $sample_id | jq -r '.[0] | .url')
+        urls=\$(ffq --ftp $sample_id | jq -r '.[].url')
+
+        link_1=\$(echo "\$urls" | sed -n '1p')
         if [ -z "\$link_1" ]; then
-            echo "Error: failed to retrieve fastq1 link for $sample_id" >&2
+            echo "Error: failed to retrieve FASTQ link for $sample_id" >&2
             exit 1
         fi
 
-        link_2=\$(ffq --ftp $sample_id | jq -r '.[1] | .url')
-        if [ -z "\$link_2" ]; then
-            echo "Error: failed to retrieve fastq2 link for $sample_id" >&2
-            exit 1
-        fi
+        link_2=\$(echo "\$urls" | sed -n '2p' || true)
         """
 }
 
 process Download {
     // labels are defined in conf/base.config
-    label "process_single"
+    // label "Download_FASTQ_by_link"
 
     input:
         val sample_id

--- a/modules/local/downloader.nf
+++ b/modules/local/downloader.nf
@@ -11,7 +11,7 @@ process GetLinks {
 
     script:
         """
-        urls=\$(ffq --ftp $sample_id | jq -r '.[].url')
+        urls=\$(ffq --ftp $sample_id | jq -r '.[].url' | sed 's|^ftp://|https://|')
 
         link_1=\$(echo "\$urls" | sed -n '1p')
         if [ -z "\$link_1" ]; then

--- a/modules/local/fastp.nf
+++ b/modules/local/fastp.nf
@@ -1,3 +1,26 @@
+process FastpSingle {
+    // labels are defined in conf/base.config
+    label "process_low"
+
+    input:
+        path fq1
+
+    output:
+        path params.out_fastp_fq1,  emit: fq1
+        path params.out_fastp_json, emit: json
+        path params.out_fastp_html, emit: html
+
+    script:
+        """
+        python3.9 /usr/local/src/run.py \
+            --in-fq1 $fq1 \
+            --out-fq1 ${params.out_fastp_fq1} \
+            --disable-filters ${params.disable} \
+            --html ${params.out_fastp_html} \
+            --json ${params.out_fastp_json}
+        """
+}
+
 process FastpMerge {
     // labels are defined in conf/base.config
     // label "process_low"

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,9 @@ params {
     save_all                   = false
     run_umi_reporter           = false
 
+    paired                     = false
+    single                     = false
+
     // PyUMI options
     fq1_pattern                = null
     fq2_pattern                = null

--- a/subworkflows/download_fastq.nf
+++ b/subworkflows/download_fastq.nf
@@ -26,10 +26,8 @@ workflow DOWNLOAD_FASTQ_BY_SAMPLE_ID {
         GetLinks(sample_id)
 
         if (params.single) {
-            // только R1
             DOWNLOAD_FASTQ_BY_LINK(GetLinks.out.link_1, "")
         } else {
-            // R1 + R2
             DOWNLOAD_FASTQ_BY_LINK(GetLinks.out.link_1, GetLinks.out.link_2)
         }
 

--- a/subworkflows/pyigmap_rnaseq.nf
+++ b/subworkflows/pyigmap_rnaseq.nf
@@ -1,4 +1,4 @@
-include { FastpMockMerge } from '../modules/local/fastp.nf'
+include { FastpMockMerge; FastpSingle } from '../modules/local/fastp.nf'
 include { Vidjil } from '../modules/local/vidjil.nf'
 include { IgBlastFASTA } from '../modules/local/igblast.nf'
 include { CDR3ErrorCorrector } from '../modules/local/cdr3nt_error_corrector.nf'
@@ -9,14 +9,31 @@ workflow PYIGMAP_RNASEQ {
         fq2
 
     main:
-        FastpMockMerge(fq1, fq2)
 
-        vidjil_ref = file(params.vidjil_ref)
-        Vidjil(FastpMockMerge.out.fq12, vidjil_ref)
+        vidjil_ref   = file(params.vidjil_ref)
+        igblast_ref  = file(params.igblast_ref)
+        olga_models  = file(params.olga_models)
 
-        igblast_ref = file(params.igblast_ref)
-        IgBlastFASTA(Vidjil.out.fasta, igblast_ref)
+        if (params.paired) {
 
-        olga_models = file(params.olga_models)
-        CDR3ErrorCorrector(IgBlastFASTA.out.annotation, olga_models, FastpMockMerge.out.json)
+            FastpMockMerge(fq1, fq2)
+            Vidjil(FastpMockMerge.out.fq12, vidjil_ref)
+            IgBlastFASTA(Vidjil.out.fasta, igblast_ref)
+            CDR3ErrorCorrector(
+                IgBlastFASTA.out.annotation,
+                olga_models,
+                FastpMockMerge.out.json
+            )
+
+        } else {
+
+            FastpSingle(fq1)
+            Vidjil(FastpSingle.out.fq1, vidjil_ref)
+            IgBlastFASTA(Vidjil.out.fasta, igblast_ref)
+            CDR3ErrorCorrector(
+                IgBlastFASTA.out.annotation,
+                olga_models,
+                FastpSingle.out.json
+            )
+        }
 }

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,7 @@
+SRR32033075.fastq.gz
+-----
+
+This is single-end data for integration test
+Source: ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR320/075/SRR32033075/SRR32033075.fastq.gz
+Downloaded: 14/01/2026
+Size: 25Mb

--- a/tests/test_main.yml
+++ b/tests/test_main.yml
@@ -4,6 +4,7 @@
   command: nextflow run main.nf
     --library rnaseq
     --sample_id SRR3743469
+    --paired
     --first_reads 10000
     --outdir ./
   files:
@@ -14,6 +15,7 @@
   command: nextflow run main.nf
     --library amplicon
     --sample_id ERR7425614
+    --paired
     --fq2_pattern "^TGGTATCAACGCAGAGTAC(UMI:N{19})TCTTGGGGG"
     --first_reads 10
     --outdir ./
@@ -26,6 +28,18 @@
     --library amplicon
     --fq1 https://zenodo.org/records/11103555/files/fmba_TRAB_R1.fastq.gz
     --fq2 https://zenodo.org/records/11103555/files/fmba_TRAB_R2.fastq.gz
+    --paired
+    --first_reads 5000
+    --outdir ./
+  files:
+    - path: "pyigmap.tar.gz"
+- name: test_main_single-end
+  tags:
+    - integration-tests
+  command: nextflow run main.nf
+    --library rnaseq
+    --fq1 tests/fixtures/SRR32033075.fastq.gz
+    --single
     --first_reads 5000
     --outdir ./
   files:


### PR DESCRIPTION
1. Add a new parameter `--single` or `--paired` (depending on the data type) to the command used to run the pipeline

2. Add support of single-end RNA-seq data to **fastp** step (process FastpSingle)

3. Add **fixture** and minimal **integration test** for single-end RNA-seq data 

4. Update documentation (**Usage** section)
